### PR TITLE
去掉swoole的依赖项

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "hyperf-extension/auth",
+    "name": "vfowo/auth",
     "type": "library",
     "license": "MIT",
     "keywords": [
@@ -34,7 +34,7 @@
     },
     "require": {
         "php": ">=8.0",
-        "hyperf-extension/hashing": "*",
+        "hyperf-extension/hashing": "~3.0.0",
         "hyperf/command": "~3.0.0",
         "hyperf/config": "~3.0.0",
         "hyperf/database": "~3.0.0",
@@ -52,8 +52,8 @@
     },
     "suggest": {
         "hyperf/session": "Required to use session guard.",
-        "hyperf-extension/cookie": "Required to use session guard.",
-        "hyperf-extension/jwt": "Required to use JWT guard."
+        "hyperf-extension/cookie": "Required to use session guard.--Not Support Temporary",
+        "vfowo/jwt": "Required to use JWT guard."
     },
     "config": {
         "sort-packages": true

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,6 @@
     },
     "require": {
         "php": ">=8.0",
-        "ext-swoole": ">=4.5",
         "hyperf-extension/hashing": "*",
         "hyperf/command": "~3.0.0",
         "hyperf/config": "~3.0.0",

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,10 @@
         {
             "name": "Taylor Otwell",
             "email": "taylor@laravel.com"
+        },
+        {
+            "name": "Gently",
+            "email": "xiangjihan@gmail.com"
         }
     ],
     "autoload": {


### PR DESCRIPTION
因为swoole和swow的依赖，在使用hyperf-skeleton /swow-skeleton创建项目时就有过约束，所以此处多余。另外如果非swoole/swow项目使用这个库，纯属多余。